### PR TITLE
Add login page and require authentication for index

### DIFF
--- a/notasplus/generales/templates/generales/login.html
+++ b/notasplus/generales/templates/generales/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h1>Ingresar al sistema</h1>
+    {% if form.errors %}
+        <p style="color: red;">Usuario o contraseña incorrectos.</p>
+    {% endif %}
+    <form method="post">
+        {% csrf_token %}
+        <label for="id_username">Usuario:</label>
+        <input type="text" name="username" id="id_username" required><br>
+        <label for="id_password">Contraseña:</label>
+        <input type="password" name="password" id="id_password" required><br>
+        <button type="submit">Entrar</button>
+    </form>
+</body>
+</html>

--- a/notasplus/generales/views.py
+++ b/notasplus/generales/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
 
 
+@login_required
 def index(request):
     return render(request, 'generales/index.html')

--- a/notasplus/notasplus/settings.py
+++ b/notasplus/notasplus/settings.py
@@ -122,3 +122,8 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Login configuration
+LOGIN_URL = '/'
+LOGIN_REDIRECT_URL = '/home/'
+LOGOUT_REDIRECT_URL = '/'

--- a/notasplus/notasplus/urls.py
+++ b/notasplus/notasplus/urls.py
@@ -16,8 +16,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include('generales.urls')),
+    path('', auth_views.LoginView.as_view(template_name='generales/login.html'), name='login'),
+    path('login/', auth_views.LoginView.as_view(template_name='generales/login.html')),  # optional explicit login path
+    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    path('home/', include('generales.urls')),
 ]


### PR DESCRIPTION
## Summary
- create a basic login form
- mark the index view as login required
- route the root URL to the login view
- set up login and logout URLs and redirects

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6859fbb6c1f0832cbdc1f2f1dcec91aa