### PR TITLE
Add team management views and forms

### DIFF
--- a/notasplus/generales/forms.py
+++ b/notasplus/generales/forms.py
@@ -1,6 +1,6 @@
 # generales/forms.py
 from django import forms
-from equipos.models import Materia,Alumno
+from equipos.models import Materia, Alumno, Equipo
 
 
 class MateriaForm(forms.ModelForm):
@@ -64,4 +64,27 @@ class AlumnoForm(forms.ModelForm):
         }
         help_texts = {
             'año_de_generacion': 'Ejemplo: 2021',
+        }
+
+
+class EquipoForm(forms.ModelForm):
+    class Meta:
+        model = Equipo
+        fields = ['nombre', 'alumnos', 'materias']
+        widgets = {
+            'nombre': forms.TextInput(attrs={
+                'class': 'form-control mb-3',
+                'placeholder': 'Nombre del equipo',
+            }),
+            'alumnos': forms.SelectMultiple(attrs={
+                'class': 'form-select mb-3',
+            }),
+            'materias': forms.SelectMultiple(attrs={
+                'class': 'form-select mb-3',
+            }),
+        }
+        labels = {
+            'nombre': 'Nombre',
+            'alumnos': 'Alumnos',
+            'materias': 'Materias',
         }

--- a/notasplus/generales/templates/generales/equipo_detail.html
+++ b/notasplus/generales/templates/generales/equipo_detail.html
@@ -1,0 +1,28 @@
+{% extends 'generales/base.html' %}
+
+{% block title %}Equipo: {{ equipo.nombre }}{% endblock %}
+
+{% block content %}
+  <h1>{{ equipo.nombre }}</h1>
+  <p><strong>Puntos:</strong> {{ equipo.puntos }}</p>
+
+  <h4>Materias:</h4>
+  <ul>
+    {% for m in equipo.materias.all %}
+      <li>{{ m.nombre }}</li>
+    {% empty %}
+      <li>Sin materias.</li>
+    {% endfor %}
+  </ul>
+
+  <h4>Alumnos:</h4>
+  <ul>
+    {% for a in equipo.alumnos.all %}
+      <li>{{ a }}</li>
+    {% empty %}
+      <li>Sin alumnos.</li>
+    {% endfor %}
+  </ul>
+
+  <a href="{% url 'home' %}" class="btn btn-secondary">← Volver al inicio</a>
+{% endblock %}

--- a/notasplus/generales/templates/generales/equipo_form.html
+++ b/notasplus/generales/templates/generales/equipo_form.html
@@ -1,12 +1,28 @@
 {% extends 'generales/base.html' %}
 
-{% block title %}Crear Grupo{% endblock %}
+{% block title %}Crear Equipo{% endblock %}
 
 {% block content %}
-  <h1>Crear Grupo</h1>
-  <form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="btn btn-success">Guardar</button>
-  </form>
+  <div class="form-container">
+    <h1 class="mb-4">Crear Equipo</h1>
+    <form method="post" novalidate class="modern-form">
+      {% csrf_token %}
+      <div class="form-group">
+        {{ form.nombre.label_tag }}
+        {{ form.nombre }}
+      </div>
+      <div class="form-group">
+        {{ form.materias.label_tag }}
+        {{ form.materias }}
+      </div>
+      <div class="form-group">
+        {{ form.alumnos.label_tag }}
+        {{ form.alumnos }}
+      </div>
+      <button type="submit" class="btn-primary-action">
+        <i class="fa fa-save me-2"></i>Guardar
+      </button>
+      <a href="{% url 'home' %}" class="btn-secondary-action ms-2">Cancelar</a>
+    </form>
+  </div>
 {% endblock %}

--- a/notasplus/generales/templates/generales/materia_detail.html
+++ b/notasplus/generales/templates/generales/materia_detail.html
@@ -8,11 +8,54 @@
     <p><strong>Código:</strong> {{ materia.codigo }}</p>
   {% endif %}
 
-  {# Aquí NO listamos equipos, sólo los detalles de la materia #}
+  <div class="d-flex justify-content-end mb-3">
+    <a href="{% url 'equipo_create' %}" class="btn btn-create-primary">
+      <i class="fa fa-plus me-2"></i>Crear Equipo
+    </a>
+  </div>
+
+  <div class="equipo-grid mb-4">
+    {% for equipo in equipos %}
+      <div class="equipo-card">
+        <h5 class="equipo-card-title">{{ equipo.nombre }}</h5>
+        <p class="equipo-points"><strong>Puntos:</strong> {{ equipo.puntos }}</p>
+        <div class="equipo-card-actions">
+          <a href="{% url 'equipo_detail' equipo.pk %}" class="btn-materia-detail">Ver Detalles</a>
+        </div>
+      </div>
+    {% empty %}
+      <p>No hay equipos registrados para esta materia.</p>
+    {% endfor %}
+  </div>
 
   <div class="mt-4">
     <a href="{% url 'materia_list' %}" class="btn btn-secondary">
       ← Volver a Materias
     </a>
   </div>
+{% endblock %}
+
+{% block extra_css %}
+  {{ block.super }}
+  <style>
+    .equipo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+      gap: 1rem;
+    }
+    .equipo-card {
+      background: var(--surface-color);
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius);
+      padding: 1rem;
+      box-shadow: var(--shadow-sm);
+    }
+    .equipo-card-title {
+      margin: 0 0 .5rem;
+      font-weight: 600;
+    }
+    .equipo-card-actions {
+      margin-top: .5rem;
+    }
+  </style>
 {% endblock %}

--- a/notasplus/generales/urls.py
+++ b/notasplus/generales/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     # Equipos...
     path('equipos/crear/',           views.EquipoCreateView.as_view(),  name='equipo_create'),
     path('equipos/',                 views.EquipoListView.as_view(),    name='equipo_list'),
+    path('equipos/<int:pk>/',        views.EquipoDetailView.as_view(),  name='equipo_detail'),
 ]

--- a/notasplus/generales/views.py
+++ b/notasplus/generales/views.py
@@ -5,7 +5,7 @@ from django.views.generic import TemplateView, CreateView, ListView, DetailView
 from equipos.models import Alumno, Materia, Equipo
 from django.db.models import Sum
 
-from generales.forms import AlumnoForm, MateriaForm
+from generales.forms import AlumnoForm, MateriaForm, EquipoForm
 
 class IndexView(LoginRequiredMixin, TemplateView):
     template_name = 'generales/index.html'
@@ -40,7 +40,7 @@ class MateriaListView(LoginRequiredMixin, ListView):
 
 class EquipoCreateView(LoginRequiredMixin, CreateView):
     model = Equipo
-    fields = ['nombre', 'alumnos', 'materias']
+    form_class = EquipoForm
     template_name = 'generales/equipo_form.html'
     success_url = reverse_lazy('home')
 
@@ -50,7 +50,18 @@ class EquipoListView(LoginRequiredMixin, ListView):
     context_object_name = 'equipos'
     template_name = 'generales/equipo_list.html'
 
+
+class EquipoDetailView(LoginRequiredMixin, DetailView):
+    model = Equipo
+    context_object_name = 'equipo'
+    template_name = 'generales/equipo_detail.html'
+
 class MateriaDetailView(LoginRequiredMixin, DetailView):
     model = Materia
     context_object_name = 'materia'
     template_name = 'generales/materia_detail.html'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['equipos'] = self.object.equipos.all()
+        return ctx


### PR DESCRIPTION
## Summary
- create `EquipoForm` model form
- add `EquipoDetailView` and extend `MateriaDetailView` with team cards
- improve team form template
- add template for viewing team details
- wire up new view in URLs

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_685a99470f9c832c87de3d23945d0162